### PR TITLE
Landingpage - Visible grey Booking-button when not logged in

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -95,13 +95,16 @@ const page = async () => {
             Pris: 899:-
           </div>
           <div className='flex justify-start'>
-            {session && (
-              <Link
-                href='/bookings'
-                className='inline-block text-sm sm:text-base bg-[#2e7d32] text-[#f0fff0] px-4 py-2 rounded font-bold hover:bg-[#27642a] transition-colors'>
-                BOKA
-              </Link>
-            )}
+            <Link
+              href={session ? '/bookings' : '/login'}
+              className={
+                session
+                  ? 'inline-block text-sm sm:text-base bg-[#2e7d32] text-[#f0fff0] px-4 py-2 rounded font-bold hover:bg-[#27642a] transition-colors'
+                  : 'inline-block text-sm sm:text-base bg-gray-300 text-gray-600 px-4 py-2 rounded font-bold cursor-not-allowed'
+              }>
+              {' '}
+              BOKA{' '}
+            </Link>
           </div>
         </div>
       </section>
@@ -168,13 +171,16 @@ const page = async () => {
             Pris: 599:-
           </div>
           <div className='flex justify-start'>
-            {session && (
-              <Link
-                href='/bookings'
-                className='inline-block text-sm sm:text-base bg-[#2e7d32] text-[#f0fff0] px-4 py-2 rounded font-bold hover:bg-[#27642a] transition-colors'>
-                BOKA
-              </Link>
-            )}
+            <Link
+              href={session ? '/bookings' : '/login'}
+              className={
+                session
+                  ? 'inline-block text-sm sm:text-base bg-[#2e7d32] text-[#f0fff0] px-4 py-2 rounded font-bold hover:bg-[#27642a] transition-colors'
+                  : 'inline-block text-sm sm:text-base bg-gray-300 text-gray-600 px-4 py-2 rounded font-bold cursor-not-allowed'
+              }>
+              {' '}
+              BOKA{' '}
+            </Link>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Before
<img width="1915" height="837" alt="Image" src="https://github.com/user-attachments/assets/5c7fc30b-b06f-4cea-bf76-703db3c51e0c" />

After
<img width="1900" height="845" alt="image" src="https://github.com/user-attachments/assets/9c0053e9-11a0-48ff-8710-4c2404f2e300" />


Now the booking button in the text is only visible when you are logged in. Make it also visible when you are not logged in. 
When you are not logged in the background color on the button should be a light grey color. The buttons background color when you are logged in should remain the green color.

These changes should be handled in:

```
app/page.tsx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the booking link to adapt based on authentication status. When logged in, it displays as an enabled button linking to your bookings. When logged out, it appears as a disabled button prompting you to log in first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->