### PR TITLE
40 password visibility toggle eyeeyeoff

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -154,6 +154,7 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className='border border-[#2e7d32] rounded-md p-2'
+              placeholder='exempel@gmail.com'
               required
             />
           </label>
@@ -165,6 +166,7 @@ export default function LoginPage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className='border border-[#2e7d32] rounded-md p-2 pr-10 w-full'
+                placeholder='********'
                 required
               />
               <PasswordVisibility
@@ -225,7 +227,7 @@ export default function LoginPage() {
                   <input
                     name='postalCode'
                     className='border border-[#2e7d32] rounded-md p-2'
-                    placeholder='131 98'
+                    placeholder='13198'
                   />
                 </label>
                 <label className='flex flex-col'>
@@ -243,7 +245,7 @@ export default function LoginPage() {
                   name='phone'
                   type='tel'
                   className='border border-[#2e7d32] rounded-md p-2'
-                  placeholder='031-12 34 56'
+                  placeholder='0709123456'
                 />
               </label>
               <label className='flex flex-col'>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import PasswordVisibility from '@/components/PasswordVisibility';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -53,6 +54,8 @@ export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showRegisterPassword, setShowRegisterPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -156,19 +159,25 @@ export default function LoginPage() {
           </label>
           <label className='flex flex-col'>
             <span className='mb-1'>Lösenord</span>
-            <input
-              type='password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className='border border-[#2e7d32] rounded-md p-2'
-              required
-            />
+            <div className='relative'>
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className='border border-[#2e7d32] rounded-md p-2 pr-10 w-full'
+                required
+              />
+              <PasswordVisibility
+                showPassword={showPassword}
+                setShowPassword={setShowPassword}
+              />
+            </div>
           </label>
           {error && <p className='text-red-600'>{error}</p>}
           <button
             type='submit'
             disabled={submitting}
-            className='login-button font-medium disabled:opacity-70 disabled:cursor-not-allowed'>
+            className='login-button font-medium disabled:opacity-70 disabled:cursor-not-allowed cursor-pointer'>
             {submitting ? 'Loggar in…' : 'Logga in'}
           </button>
           <button
@@ -249,15 +258,21 @@ export default function LoginPage() {
               </label>
               <label className='flex flex-col'>
                 <span className='mb-1'>Lösenord</span>
-                <input
-                  name='password'
-                  type='password'
-                  required
-                  className='border border-[#2e7d32] rounded-md p-2'
-                  placeholder='********'
-                />
+                <div className='relative'>
+                  <input
+                    name='password'
+                    type={showRegisterPassword ? 'text' : 'password'}
+                    required
+                    className='border border-[#2e7d32] rounded-md p-2 pr-10 w-full'
+                    placeholder='********'
+                  />
+                  <PasswordVisibility
+                    showPassword={showRegisterPassword}
+                    setShowPassword={setShowRegisterPassword}
+                  />
+                </div>
               </label>
-              <label className='inline-flex items-center gap-2'>
+              <label className='inline-flex items-center gap-2 cursor-pointer'>
                 <input
                   name='termsAccepted'
                   type='checkbox'
@@ -272,7 +287,7 @@ export default function LoginPage() {
               <div className='flex gap-3'>
                 <button
                   type='submit'
-                  className='login-button font-medium'>
+                  className='login-button font-medium cursor-pointer'>
                   Registrera
                 </button>
                 <button

--- a/components/PasswordVisibility.tsx
+++ b/components/PasswordVisibility.tsx
@@ -15,7 +15,7 @@ export default function PasswordVisibility({
       onClick={() => setShowPassword(!showPassword)}
       aria-label={showPassword ? 'Dölj lösenord' : 'Visa lösenord'}
       aria-pressed={showPassword}
-      className='absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[#111827] transition-colors hover:text-black cursor-pointer'>
+      className='absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[#111827] transition-colors hover:text-gray-500 cursor-pointer'>
       {showPassword ? (
         <svg
           xmlns='http://www.w3.org/2000/svg'

--- a/components/PasswordVisibility.tsx
+++ b/components/PasswordVisibility.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+interface PasswordVisibilityProps {
+  showPassword: boolean;
+  setShowPassword: (show: boolean) => void;
+}
+
+export default function PasswordVisibility({
+  showPassword,
+  setShowPassword,
+}: PasswordVisibilityProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => setShowPassword(!showPassword)}
+      aria-label={showPassword ? 'Dölj lösenord' : 'Visa lösenord'}
+      aria-pressed={showPassword}
+      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[#111827] transition-colors hover:text-black focus:outline-none focus:ring-2 focus:ring-[#2e7d32] rounded"
+    >
+      {showPassword ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z" />
+          <circle cx="12" cy="12" r="3" />
+          <line
+            x1="2"
+            y1="2"
+            x2="22"
+            y2="22"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/components/PasswordVisibility.tsx
+++ b/components/PasswordVisibility.tsx
@@ -11,52 +11,57 @@ export default function PasswordVisibility({
 }: PasswordVisibilityProps) {
   return (
     <button
-      type="button"
+      type='button'
       onClick={() => setShowPassword(!showPassword)}
       aria-label={showPassword ? 'Dölj lösenord' : 'Visa lösenord'}
       aria-pressed={showPassword}
-      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[#111827] transition-colors hover:text-black focus:outline-none focus:ring-2 focus:ring-[#2e7d32] rounded"
-    >
+      className='absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[#111827] transition-colors hover:text-black cursor-pointer'>
       {showPassword ? (
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-        >
-          <path d="M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z" />
-          <circle cx="12" cy="12" r="3" />
+          xmlns='http://www.w3.org/2000/svg'
+          width='20'
+          height='20'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='3'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden>
+          <path d='M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z' />
+          <circle
+            cx='12'
+            cy='12'
+            r='3'
+          />
           <line
-            x1="2"
-            y1="2"
-            x2="22"
-            y2="22"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
+            x1='2'
+            y1='2'
+            x2='22'
+            y2='22'
+            stroke='currentColor'
+            strokeWidth='3'
+            strokeLinecap='round'
           />
         </svg>
       ) : (
         <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden
-        >
-          <path d="M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z" />
-          <circle cx="12" cy="12" r="3" />
+          xmlns='http://www.w3.org/2000/svg'
+          width='20'
+          height='20'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='3'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          aria-hidden>
+          <path d='M1.5 12C3.1 9.2 7 5 12 5s8.9 4.2 10.5 7c-1.6 2.8-5.5 7-10.5 7S3.1 14.8 1.5 12z' />
+          <circle
+            cx='12'
+            cy='12'
+            r='3'
+          />
         </svg>
       )}
     </button>


### PR DESCRIPTION
Before:
<img width="708" height="618" alt="Image" src="https://github.com/user-attachments/assets/9c2df043-c0e5-47dc-8f7c-8166de43b73a" />

After:
<img width="677" height="587" alt="image" src="https://github.com/user-attachments/assets/4c57a4e5-96fd-4e55-b438-52c9c1f214be" />

I wanted to have icons in the password input fields that toggles the visibility for the password. This function weren't there before.

These fixes were handled in these files:

```
components/PasswordVisibility.tsx
app/login/page.tsx
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggle to login and registration forms, allowing users to show or hide their password input for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->